### PR TITLE
adjusting breakout candle minimum size

### DIFF
--- a/buy_signal_helper.py
+++ b/buy_signal_helper.py
@@ -84,7 +84,9 @@ def calculate_signal(dataframe):
                                   df_test.iloc[-3]['Close'] < df_test.iloc[-3]['SMA_9'])
 
                     breakout_candle = (df_test.iloc[-2]['Open'] < df_test.iloc[-2]['SMA_9'] and
-                                       df_test.iloc[-2]['Close'] > df_test.iloc[-2]['SMA_9'])
+                                       df_test.iloc[-2]['Close'] > df_test.iloc[-2]['SMA_9'] and
+                                       # Breakout greater than 1%
+                                       (df_test.iloc[-2]['Close'] - df_test.iloc[-2]['Open'])/df_test.iloc[-2]['Open']*100 > 1)
 
                     confirmation_candle = (df_test.iloc[-1]['Open'] > df_test.iloc[-1]['SMA_9'] and
                                            df_test.iloc[-1]['Close'] > df_test.iloc[-1]['SMA_9'] and


### PR DESCRIPTION
Getting text alerts for minimal moves that don't show enough strength to continue upward momentum, adjusting signal mechanism to only alert when the breakout candle is greater than 1%. Should leave this branch open after merging for future adjustments if 1% does not allow the desired number of signals.